### PR TITLE
Example: pure HTML and JS

### DIFF
--- a/map-sdk/html-and-js-example/README.md
+++ b/map-sdk/html-and-js-example/README.md
@@ -1,0 +1,5 @@
+# Map SDK example with HTML and JS
+
+This example demonstrates how to work with Map SDK without any framework or bundler available, in a pure JS and HTML setup.
+
+This is an example for Foursquare's [Map SDK](https://location.foursquare.com/developer/docs/studio-map-sdk-introduction) that allows you to programmatically render [Foursquare Studio](https://studio.foursquare.com/) maps within your website and with your own data.

--- a/map-sdk/html-and-js-example/index.html
+++ b/map-sdk/html-and-js-example/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basic HTML and JS example</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      #map-container {
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      type="module" makes it possible to work with JS modules
+      see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
+    -->
+    <script type="module">
+      // we import a bundled version of Map SDK from unpkg CDN
+      import {createMap} from 'https://unpkg.com/@unfolded/map-sdk@latest/dist/index.js';
+
+      // we now can call functions as we would anywhere else
+      const map = createMap({
+        container: document.getElementById('map-container')
+      });
+    </script>
+
+    <div id="map-container"></div>
+  </body>
+</html>


### PR DESCRIPTION
Added an example to show how to use Map SDK without and framework or bundler, in a setup with pure JS and HTML.