### PR TITLE
fix(notebooks): Update Colab link, remove Binder link

### DIFF
--- a/python-notebooks/01 - Introduction.ipynb
+++ b/python-notebooks/01 - Introduction.ipynb
@@ -8,12 +8,12 @@
     "# Introduction to Studio Map SDK\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/01%20-%20Introduction.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/01%20-%20Introduction.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/01%20-%20Introduction.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/01%20-%20Introduction.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/02 - Local maps.ipynb
+++ b/python-notebooks/02 - Local maps.ipynb
@@ -8,12 +8,12 @@
     "# Local maps\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/02%20-%20Local%20maps.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/02%20-%20Local%20maps.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/02%20-%20Local%20maps.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/02%20-%20Local%20maps.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/03 - Layers.ipynb
+++ b/python-notebooks/03 - Layers.ipynb
@@ -8,12 +8,12 @@
     "# Layers\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/03%20-%20Layers.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/03%20-%20Layers.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/03%20-%20Layers.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/03%20-%20Layers.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/04 - Filters.ipynb
+++ b/python-notebooks/04 - Filters.ipynb
@@ -8,12 +8,12 @@
     "# Filters\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/04%20-%20Filters.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/04%20-%20Filters.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/04%20-%20Filters.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/04%20-%20Filters.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/05 - Timeline.ipynb
+++ b/python-notebooks/05 - Timeline.ipynb
@@ -8,12 +8,12 @@
     "# Timeline\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/05%20-%20Timeline.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/05%20-%20Timeline.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/05%20-%20Timeline.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/05%20-%20Timeline.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/06 - Crossfilter.ipynb
+++ b/python-notebooks/06 - Crossfilter.ipynb
@@ -8,12 +8,12 @@
     "# Cross-filtering\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/06%20-%20Crossfilter.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/06%20-%20Crossfilter.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/06%20-%20Crossfilter.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/06%20-%20Crossfilter.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/07 - Eventhandling.ipynb
+++ b/python-notebooks/07 - Eventhandling.ipynb
@@ -7,12 +7,12 @@
     "# Handling hover and click map events\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/07%20-%20Eventhandling.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/07%20-%20Eventhandling.ipynb\n",
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/07%20-%20Eventhandling.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/07%20-%20Eventhandling.ipynb -->\n",
     "\n",
     "Using the [set_map_event_handlers](https://docs.unfolded.ai/map-sdk/api/set-map-event-handlers) function it is possible to define event callbacks for the `on_hover` and `on_click` events. These events can return the data from the layer points or polygons if the user clicks or hovers on them."
    ]

--- a/python-notebooks/08 - Tensorflow_prediction.ipynb
+++ b/python-notebooks/08 - Tensorflow_prediction.ipynb
@@ -8,12 +8,12 @@
     "# House Price Prediction With TensorFlow\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/08%20-%20Tensorflow_prediction.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/08%20-%20Tensorflow_prediction.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/08%20-%20Tensorflow_prediction.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/08%20-%20Tensorflow_prediction.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/09 - Suitability_Analysis.ipynb
+++ b/python-notebooks/09 - Suitability_Analysis.ipynb
@@ -8,12 +8,12 @@
     "# Suitability Analysis for a new Venue Location\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/09%20-%20Suitability_Analysis.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/09%20-%20Suitability_Analysis.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/09%20-%20Suitability_Analysis.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/09%20-%20Suitability_Analysis.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/10 - Kuwala Popularity Correlation.ipynb
+++ b/python-notebooks/10 - Kuwala Popularity Correlation.ipynb
@@ -11,12 +11,12 @@
     "# Kuwala - Popularity Correlation\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/10%20-%20Kuwala%20Popularity%20Correlation.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/10%20-%20Kuwala%20Popularity%20Correlation.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/10%20-%20Kuwala%20Popularity%20Correlation.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/10%20-%20Kuwala%20Popularity%20Correlation.ipynb -->"
    ]
   },
   {

--- a/python-notebooks/11 - Pytorch Trip Duration.ipynb
+++ b/python-notebooks/11 - Pytorch Trip Duration.ipynb
@@ -8,12 +8,12 @@
     "# Studio SDK Machine Learning Demo (LA Bike Share)\n",
     "\n",
     "[![open_in_colab][colab_badge]][colab_notebook_link]\n",
-    "[![open_in_binder][binder_badge]][binder_notebook_link]\n",
+    "<!-- [![open_in_binder][binder_badge]][binder_notebook_link] -->\n",
     "\n",
     "[colab_badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
-    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/notebooks/11%20-%20Pytorch%20Trip%20Duration.ipynb\n",
-    "[binder_badge]: https://mybinder.org/badge_logo.svg\n",
-    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/notebooks/11%20-%20Pytorch%20Trip%20Duration.ipynb"
+    "[colab_notebook_link]: https://colab.research.google.com/github/foursquare/fsq-studio-sdk-examples/blob/master/python-notebooks/11%20-%20Pytorch%20Trip%20Duration.ipynb\n",
+    "<!-- [binder_badge]: https://mybinder.org/badge_logo.svg\n",
+    "[binder_notebook_link]: https://mybinder.org/v2/gh/foursquare/fsq-studio-sdk-examples/master?urlpath=lab/tree/python-notebooks/11%20-%20Pytorch%20Trip%20Duration.ipynb -->"
    ]
   },
   {


### PR DESCRIPTION
Fixes Colab links after directory rename.

Binder is currently broken, the studio instance loads, but the map is blank. Python commands can change JS map state, but usually time out before returning values to Python. removing the links to Binder until we have bandwith to debug.
<img width="664" alt="Screenshot 2024-03-26 at 6 01 48 PM" src="https://github.com/foursquare/fsq-studio-sdk-examples/assets/9853610/7068c7a0-793f-44b5-acce-c8cf543f7852">